### PR TITLE
Move navbars to top of all pages

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -8,7 +8,7 @@ body:not(.home-page) .navbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  z-index: 1000;
+  z-index: 9999; /* Increased z-index to ensure navbar is always on top */
   overflow: hidden;
 }
 

--- a/shop/templates/shop/address_form.html
+++ b/shop/templates/shop/address_form.html
@@ -26,7 +26,7 @@ body {
 
 .form-container {
     max-width: 800px;
-    margin: 40px auto;
+    margin: 140px auto 40px auto; /* Extra top margin for navbar */
     padding: 20px;
 }
 

--- a/shop/templates/shop/cart.html
+++ b/shop/templates/shop/cart.html
@@ -41,9 +41,8 @@
 
     .cart-container {
         background: #FFFFFF;
-        min-height: 100vh;
-        padding: 40px 0;
-        margin-top: 120px;
+        min-height: calc(100vh - 100px); /* Account for navbar */
+        padding: 140px 0 40px 0; /* Extra top padding for navbar, replacing margin-top */
     }
     
     .cart-card {

--- a/shop/templates/shop/change_password.html
+++ b/shop/templates/shop/change_password.html
@@ -90,7 +90,7 @@
 
 <style>
 .change-password-container {
-    min-height: 100vh;
+    min-height: calc(100vh - 100px); /* Account for navbar */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -98,6 +98,7 @@
     position: relative;
     overflow: hidden;
     padding: 2rem;
+    padding-top: 120px; /* Extra top padding for navbar */
 }
 
 .change-password-card {

--- a/shop/templates/shop/checkout.html
+++ b/shop/templates/shop/checkout.html
@@ -8,8 +8,8 @@
     .checkout-container {
         background: linear-gradient(135deg, #4B2E2B 0%, #7B3F00 50%, #C97C5D 100%);
         background-attachment: fixed;
-        min-height: 100vh;
-        padding: 40px 0;
+        min-height: calc(100vh - 100px); /* Account for navbar */
+        padding: 140px 0 40px 0; /* Extra top padding for navbar */
     }
     
     .checkout-card {

--- a/shop/templates/shop/dashboard.html
+++ b/shop/templates/shop/dashboard.html
@@ -6,9 +6,9 @@
 {% block extrastyle %}
 <style>
     .dashboard-container {
-        padding: 20px;
+        padding: 120px 20px 20px 20px; /* Extra top padding for navbar */
         background: #f8f9fa;
-        min-height: 100vh;
+        min-height: calc(100vh - 100px); /* Account for navbar */
     }
     
     .stats-grid {

--- a/shop/templates/shop/edit_profile.html
+++ b/shop/templates/shop/edit_profile.html
@@ -26,7 +26,7 @@ body {
 
 .form-container {
     max-width: 900px;
-    margin: 40px auto;
+    margin: 140px auto 40px auto; /* Extra top margin for navbar */
     padding: 20px;
 }
 

--- a/shop/templates/shop/login.html
+++ b/shop/templates/shop/login.html
@@ -88,7 +88,8 @@
 
 <style>
 .login-container {
-    min-height: 100vh;
+    min-height: calc(100vh - 100px); /* Account for navbar */
+    padding-top: 20px; /* Additional spacing from navbar */
     display: flex;
     align-items: center;
     justify-content: center;

--- a/shop/templates/shop/order_detail.html
+++ b/shop/templates/shop/order_detail.html
@@ -7,8 +7,8 @@
 <style>
     .order-detail-container {
         background: #FFFFFF;
-        min-height: 100vh;
-        padding: 40px 0;
+        min-height: calc(100vh - 100px); /* Account for navbar */
+        padding: 140px 0 40px 0; /* Extra top padding for navbar */
     }
     
     .order-detail-card {

--- a/shop/templates/shop/product_detail.html
+++ b/shop/templates/shop/product_detail.html
@@ -45,7 +45,7 @@
 
     /* Main content starts with proper top margin for base navbar */
     .main-content {
-        margin-top: 80px; /* Space for base navbar */
+        margin-top: 120px; /* Space for base navbar - increased for better spacing */
     }
 
 

--- a/shop/templates/shop/product_list.html
+++ b/shop/templates/shop/product_list.html
@@ -8,7 +8,7 @@
     body {
         background: #FFFFFF;
         color: #4B2E2B;
-        padding-top: 80px; /* Adjusted for base navbar */
+        padding-top: 120px; /* Adjusted for base navbar - increased for better spacing */
     }
 
 

--- a/shop/templates/shop/recommendations.html
+++ b/shop/templates/shop/recommendations.html
@@ -8,8 +8,8 @@
 /* Recommendations Page Styling */
 .recommendations-page {
     background: linear-gradient(135deg, #FFF8F0 0%, #F3E9DC 100%);
-    min-height: 100vh;
-    padding: 2rem 0;
+    min-height: calc(100vh - 100px); /* Account for navbar */
+    padding: 120px 0 2rem 0; /* Extra top padding for navbar */
 }
 
 .page-header {

--- a/shop/templates/shop/register.html
+++ b/shop/templates/shop/register.html
@@ -7,8 +7,8 @@
 <style>
     .register-container {
         background: #FFFFFF;
-        min-height: 100vh;
-        padding: 40px 0;
+        min-height: calc(100vh - 100px); /* Account for navbar */
+        padding: 60px 0 40px 0; /* Extra top padding for navbar */
         display: flex;
         align-items: center;
         justify-content: center;

--- a/shop/templates/shop/signup.html
+++ b/shop/templates/shop/signup.html
@@ -95,7 +95,8 @@
 
 <style>
 .signup-container {
-    min-height: 100vh;
+    min-height: calc(100vh - 100px); /* Account for navbar */
+    padding-top: 20px; /* Additional spacing from navbar */
     display: flex;
     align-items: center;
     justify-content: center;

--- a/shop/templates/shop/user_profile.html
+++ b/shop/templates/shop/user_profile.html
@@ -31,8 +31,8 @@ body {
 .profile-container {
     max-width: 1400px;
     margin: 0 auto;
-    padding: 20px;
-    min-height: 100vh;
+    padding: 120px 20px 20px 20px; /* Extra top padding for navbar */
+    min-height: calc(100vh - 100px); /* Account for navbar */
 }
 
 /* ===== PROFESSIONAL HEADER ===== */

--- a/shop/templates/shop/voice_ai_assistant.html
+++ b/shop/templates/shop/voice_ai_assistant.html
@@ -25,11 +25,11 @@
     }
     
     .voice-ai-container {
-        min-height: 100vh;
+        min-height: calc(100vh - 100px); /* Account for navbar */
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 20px;
+        padding: 120px 20px 20px 20px; /* Extra top padding for navbar */
         position: relative;
     }
     


### PR DESCRIPTION
Adjusted navbar positioning and page content spacing across all non-homepage templates to ensure the navbar is consistently fixed at the top without overlapping content.

Many pages used `min-height: 100vh` for their main containers, which conflicted with the global `padding-top` applied to the body for the fixed navbar. This PR adjusts these container heights and adds appropriate top padding/margins to ensure content is always visible below the fixed navbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-55913558-876d-4576-ab5f-f5562d7ad07e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55913558-876d-4576-ab5f-f5562d7ad07e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

