### PR TITLE
Fix navbar spacing on non-home pages

### DIFF
--- a/shop/templates/shop/cart.html
+++ b/shop/templates/shop/cart.html
@@ -8,7 +8,7 @@
     body {
         background: #FFFFFF;
         color: #4B2E2B;
-        padding-top: 80px; /* Space for base navbar */
+        padding-top: 0; /* Removed excessive padding - navbar is fixed positioned */
     }
 
 

--- a/shop/templates/shop/change_password.html
+++ b/shop/templates/shop/change_password.html
@@ -98,7 +98,7 @@
     position: relative;
     overflow: hidden;
     padding: 2rem;
-    padding-top: 120px; /* Extra top padding for navbar */
+    padding-top: 0; /* Removed excessive padding - navbar is fixed positioned */
 }
 
 .change-password-card {

--- a/shop/templates/shop/product_detail.html
+++ b/shop/templates/shop/product_detail.html
@@ -45,7 +45,7 @@
 
     /* Main content starts with proper top margin for base navbar */
     .main-content {
-        margin-top: 120px; /* Space for base navbar - increased for better spacing */
+        margin-top: 0; /* Removed excessive margin - navbar is fixed positioned */
     }
 
 
@@ -97,8 +97,8 @@
 
     /* Add top margin to main content to account for fixed navbar */
     .product-detail-container {
-        margin-top: 120px;
-        min-height: calc(100vh - 120px);
+        margin-top: 0; /* Removed excessive margin - navbar is fixed positioned */
+        min-height: 100vh;
         padding: 2rem 1rem;
         display: flex;
         align-items: center;

--- a/shop/templates/shop/product_list.html
+++ b/shop/templates/shop/product_list.html
@@ -8,7 +8,7 @@
     body {
         background: #FFFFFF;
         color: #4B2E2B;
-        padding-top: 120px; /* Adjusted for base navbar - increased for better spacing */
+        padding-top: 0; /* Removed excessive padding - navbar is fixed positioned */
     }
 
 


### PR DESCRIPTION
Removes excessive top padding/margin from non-home pages to ensure the fixed navbar sticks to the top.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7a09316-4b99-4d8b-9d2d-6c25c0b88bb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7a09316-4b99-4d8b-9d2d-6c25c0b88bb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

