### PR TITLE
Fix navbar css conflicts and position

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -4,12 +4,13 @@ body:not(.home-page) .navbar {
   top: 0;
   left: 0;
   right: 0;
-  padding: 1.5rem 3rem;
+  padding: 1rem 3rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  z-index: 9999; /* Increased z-index to ensure navbar is always on top */
+  z-index: 99999; /* Increased z-index to ensure navbar is always on top */
   overflow: hidden;
+  margin: 0;
 }
 
 body:not(.home-page) .navbar::before {
@@ -281,7 +282,9 @@ body:not(.home-page) .navbar .cart-count {
 /* Responsive Design */
 @media (max-width: 768px) {
   body:not(.home-page) .navbar {
-    padding: 1rem 1.5rem;
+    padding: 0.8rem 1.5rem;
+    margin: 0;
+    top: 0;
   }
   
   body:not(.home-page) .navbar .nav-brand-text {
@@ -305,6 +308,12 @@ body:not(.home-page) .navbar .cart-count {
 }
 
 @media (max-width: 576px) {
+  body:not(.home-page) .navbar {
+    padding: 0.6rem 1rem;
+    margin: 0;
+    top: 0;
+  }
+  
   body:not(.home-page) .navbar .nav-links {
     display: none;
   }
@@ -316,11 +325,17 @@ body:not(.home-page) .navbar .cart-count {
 
 /* Ensure content doesn't get hidden behind fixed navbar */
 body:not(.home-page) {
-  padding-top: 100px;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+/* Add top margin to main content instead of body padding */
+body:not(.home-page) .main-content {
+  margin-top: 80px;
 }
 
 @media (max-width: 768px) {
-  body:not(.home-page) {
-    padding-top: 80px;
+  body:not(.home-page) .main-content {
+    margin-top: 70px;
   }
 }

--- a/shop/static/shop/style.css
+++ b/shop/static/shop/style.css
@@ -7,8 +7,8 @@
 }
 
 html, body {
-    margin: 0;
-    padding: 0;
+    margin: 0 !important;
+    padding: 0 !important;
     height: 100%;
 }
 
@@ -18,8 +18,8 @@ body {
     background-size: 100% 100vh;
     color: #FFF8F0;
     font-family: 'Vazirmatn', 'Tahoma', 'Segoe UI', Arial, sans-serif;
-    margin: 0;
-    padding: 0;
+    margin: 0 !important;
+    padding: 0 !important;
     overflow-x: hidden;
     line-height: 1.6;
     min-height: 100vh;
@@ -155,6 +155,12 @@ body {
 header, main, footer, section, div {
     margin: 0;
     padding: 0;
+}
+
+/* Specific fix for navbar positioning */
+nav.navbar {
+    margin: 0 !important;
+    top: 0 !important;
 }
 
 /* Specific fix for hero section */
@@ -1386,11 +1392,13 @@ header, main, footer, section, div {
     }
     
     .main-content {
-        padding-top: 120px;
+        margin-top: 0;
+        padding-top: 0;
     }
     
     .home-page .main-content {
         padding-top: 0 !important;
+        margin-top: 0 !important;
     }
 }
 
@@ -1436,7 +1444,8 @@ header, main, footer, section, div {
     }
     
     .main-content {
-        padding-top: 140px;
+        margin-top: 0;
+        padding-top: 0;
     }
 }
 
@@ -1478,21 +1487,14 @@ header, main, footer, section, div {
 /* Adjust main content to account for fixed navbar on non-home pages */
 .main-content {
     position: relative;
-}
-
-/* For home page with hero section, no top padding needed */
-.home-page .main-content {
+    margin-top: 0;
     padding-top: 0;
 }
 
-/* For other pages, add padding to account for fixed navbar */
-.main-content {
-    padding-top: 80px;
-}
-
-/* Override for home page */
+/* For home page with hero section, no top padding/margin needed */
 .home-page .main-content {
     padding-top: 0 !important;
+    margin-top: 0 !important;
 }
 
 .nav-menu {
@@ -1501,11 +1503,13 @@ header, main, footer, section, div {
 }
 
 .site-header {
-    position: fixed;
+    position: relative;
     top: 0;
     left: 0;
     right: 0;
     z-index: 99999999 !important;
+    margin: 0;
+    padding: 0;
 }
 
 .dropdown-toggle {


### PR DESCRIPTION
Removes top white space on non-home pages by fixing navbar positioning and resolving CSS conflicts.

The previous setup used `padding-top` on the `body` element to create space for the fixed navbar, leading to an unwanted white gap. This PR refactors the styling to position the navbar flush at the top and uses `margin-top` on the `.main-content` to correctly offset the page content, ensuring a seamless visual experience. It also unifies conflicting `position`, `margin`, and `padding` rules across `style.css` and `navbar-blur.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb6fa700-36ac-47db-9e9e-67f122530b02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb6fa700-36ac-47db-9e9e-67f122530b02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

