### PR TITLE
Fix navbar css conflicts and position

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -316,11 +316,11 @@ body:not(.home-page) .navbar .cart-count {
 
 /* Ensure content doesn't get hidden behind fixed navbar */
 body:not(.home-page) {
-  padding-top: 100px;
+  padding-top: 0 !important; /* eliminate gap above navbar */
 }
 
 @media (max-width: 768px) {
   body:not(.home-page) {
-    padding-top: 80px;
+    padding-top: 0 !important; /* keep gap removed on smaller screens */
   }
 }


### PR DESCRIPTION
Removes `padding-top` from non-home pages to eliminate the whitespace above the fixed navbar.

---
<a href="https://cursor.com/background-agent?bcId=bc-331d41bb-97fb-4fd0-9403-d53d2a774b9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-331d41bb-97fb-4fd0-9403-d53d2a774b9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

