### PR TITLE
Fix product detail page z-index conflicts

### DIFF
--- a/shop/templates/shop/product_detail.html
+++ b/shop/templates/shop/product_detail.html
@@ -243,6 +243,8 @@
         box-shadow: var(--shadow-soft);
         transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
         backdrop-filter: blur(10px);
+        position: relative; /* Ensure stacking context positioning */
+        z-index: 2; /* Bring dropdown group above quantity container */
     }
 
     .option-group:hover {


### PR DESCRIPTION
Ensure dropdowns appear above the quantity selector by establishing a proper stacking context for `.option-group`.

---
<a href="https://cursor.com/background-agent?bcId=bc-44d05a3f-5192-42c1-8dca-3c32d4aa5b8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44d05a3f-5192-42c1-8dca-3c32d4aa5b8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

