### PR TITLE
Remove profile dropdown hover box

### DIFF
--- a/shop/static/shop/dropdown-fix.css
+++ b/shop/static/shop/dropdown-fix.css
@@ -104,17 +104,4 @@
     }
 }
 
-/* Debug styles - remove in production */
-.profile-dropdown:hover::after,
-.hero-profile-dropdown:hover::after {
-    content: "Z-INDEX: 2147483647";
-    position: absolute;
-    bottom: -20px;
-    left: 0;
-    font-size: 10px;
-    color: red;
-    background: yellow;
-    padding: 2px;
-    z-index: 2147483647;
-    pointer-events: none;
-}
+/* Debug styles removed */

--- a/staticfiles/shop/dropdown-fix.css
+++ b/staticfiles/shop/dropdown-fix.css
@@ -104,17 +104,4 @@
     }
 }
 
-/* Debug styles - remove in production */
-.profile-dropdown:hover::after,
-.hero-profile-dropdown:hover::after {
-    content: "Z-INDEX: 2147483647";
-    position: absolute;
-    bottom: -20px;
-    left: 0;
-    font-size: 10px;
-    color: red;
-    background: yellow;
-    padding: 2px;
-    z-index: 2147483647;
-    pointer-events: none;
-}
+/* Debug styles removed */


### PR DESCRIPTION
Remove temporary debug styles that displayed a yellow box on profile dropdown hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-e525bb1a-6c1e-485c-b400-81d6992bc90b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e525bb1a-6c1e-485c-b400-81d6992bc90b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

