### PR TITLE
Update order details with grinding and weight

### DIFF
--- a/shop/migrations/0015_add_order_item_grind_weight_fields.py
+++ b/shop/migrations/0015_add_order_item_grind_weight_fields.py
@@ -1,0 +1,44 @@
+# Generated manually to add grind_type and weight fields to OrderItem
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shop', '0014_add_product_grind_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='orderitem',
+            name='grind_type',
+            field=models.CharField(
+                choices=[
+                    ('whole_bean', 'اسیاب نشده'),
+                    ('coarse', 'ترک'),
+                    ('medium_coarse', 'موکاپات'),
+                    ('medium', 'اسپرسو ساز نیمه صنعتی'),
+                    ('medium_fine', 'اسپرسوساز صنعتی'),
+                    ('fine', 'اسپرسوساز خانگی'),
+                ],
+                default='whole_bean',
+                max_length=20
+            ),
+        ),
+        migrations.AddField(
+            model_name='orderitem',
+            name='weight',
+            field=models.CharField(
+                choices=[
+                    ('250g', '250 گرم'),
+                    ('500g', '500 گرم'),
+                    ('1kg', '1 کیلوگرم'),
+                    ('5kg', '5 کیلوگرم'),
+                    ('10kg', '10 کیلوگرم'),
+                ],
+                default='250g',
+                max_length=10
+            ),
+        ),
+    ]

--- a/shop/models.py
+++ b/shop/models.py
@@ -218,9 +218,21 @@ class OrderItem(models.Model):
     product = models.ForeignKey(Product, on_delete=models.CASCADE)
     quantity = models.IntegerField(default=1)
     price = models.DecimalField(max_digits=10, decimal_places=2, default=0)
+    grind_type = models.CharField(max_length=20, choices=Product.GRIND_TYPE_CHOICES, default='whole_bean')
+    weight = models.CharField(max_length=10, choices=Product.WEIGHT_CHOICES, default='250g')
 
     def __str__(self):
-        return f"{self.quantity}x {self.product.name}"
+        grind_display = dict(Product.GRIND_TYPE_CHOICES).get(self.grind_type, self.grind_type)
+        weight_display = dict(Product.WEIGHT_CHOICES).get(self.weight, self.weight)
+        return f"{self.quantity}x {self.product.name} - {grind_display} - {weight_display}"
+    
+    def get_unit_price(self):
+        """Get price per unit with weight multiplier"""
+        return self.product.get_price_for_weight(self.weight)
+
+    def get_total_price(self):
+        """Calculate total price considering weight multiplier"""
+        return self.get_unit_price() * self.quantity
 
 class OrderFeedback(models.Model):
     RATING_CHOICES = [

--- a/shop/templates/admin/order_detail.html
+++ b/shop/templates/admin/order_detail.html
@@ -338,6 +338,21 @@
                 <strong style="color: #333 !important;">{{ item.product.name }}</strong>
                 <br>
                 <small style="color: #666 !important;">{{ item.product.category.name }}</small>
+                <br>
+                <div style="display: flex; gap: 10px; margin-top: 5px;">
+                    <span style="background: #f8f9fa; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; color: #666;">
+                        <i class="fas fa-cog"></i>
+                        {% for choice in item.product.GRIND_TYPE_CHOICES %}
+                            {% if choice.0 == item.grind_type %}{{ choice.1 }}{% endif %}
+                        {% endfor %}
+                    </span>
+                    <span style="background: #f8f9fa; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; color: #666;">
+                        <i class="fas fa-weight-hanging"></i>
+                        {% for choice in item.product.WEIGHT_CHOICES %}
+                            {% if choice.0 == item.weight %}{{ choice.1 }}{% endif %}
+                        {% endfor %}
+                    </span>
+                </div>
             </div>
             <div style="color: #333 !important;">{{ item.price|floatformat:0 }} تومان</div>
             <div style="color: #333 !important;">{{ item.quantity }}</div>

--- a/shop/templates/shop/cart.html
+++ b/shop/templates/shop/cart.html
@@ -118,6 +118,27 @@
         font-size: 0.9rem;
     }
     
+    .item-specs {
+        display: flex;
+        gap: 10px;
+        margin-top: 8px;
+    }
+    
+    .spec-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 6px;
+        background: #f8f9fa;
+        border-radius: 4px;
+        font-size: 0.8em;
+        color: #666;
+    }
+    
+    .spec-item i {
+        color: #4B2E2B;
+    }
+    
     .item-price {
         font-size: 1.1rem;
         font-weight: 600;
@@ -423,6 +444,20 @@
                         <div class="item-details">
                             <h3>{{ item.product.name }}</h3>
                             <p>{{ item.product.category.name }}</p>
+                            <div class="item-specs">
+                                <span class="spec-item">
+                                    <i class="fas fa-cog"></i>
+                                    {% for choice in item.product.GRIND_TYPE_CHOICES %}
+                                        {% if choice.0 == item.grind_type %}{{ choice.1 }}{% endif %}
+                                    {% endfor %}
+                                </span>
+                                <span class="spec-item">
+                                    <i class="fas fa-weight-hanging"></i>
+                                    {% for choice in item.product.WEIGHT_CHOICES %}
+                                        {% if choice.0 == item.weight %}{{ choice.1 }}{% endif %}
+                                    {% endfor %}
+                                </span>
+                            </div>
                         </div>
                         
                         <div class="item-price">

--- a/shop/templates/shop/order_detail.html
+++ b/shop/templates/shop/order_detail.html
@@ -214,6 +214,27 @@
         margin-bottom: 8px;
     }
     
+    .item-specs {
+        display: flex;
+        gap: 15px;
+        margin: 8px 0;
+    }
+    
+    .spec-item {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        padding: 4px 8px;
+        background: #f8f9fa;
+        border-radius: 6px;
+        font-size: 0.85em;
+        color: #666;
+    }
+    
+    .spec-item i {
+        color: #4B2E2B;
+    }
+    
     .item-quantity {
         color: #4B2E2B;
         font-weight: 600;
@@ -467,6 +488,20 @@
                                     <div class="item-details">
                                         <div class="item-name">{{ item.product.name }}</div>
                                         <div class="item-description">{{ item.product.description|truncatewords:10 }}</div>
+                                        <div class="item-specs">
+                                            <span class="spec-item">
+                                                <i class="fas fa-cog"></i> 
+                                                {% for choice in item.product.GRIND_TYPE_CHOICES %}
+                                                    {% if choice.0 == item.grind_type %}{{ choice.1 }}{% endif %}
+                                                {% endfor %}
+                                            </span>
+                                            <span class="spec-item">
+                                                <i class="fas fa-weight-hanging"></i> 
+                                                {% for choice in item.product.WEIGHT_CHOICES %}
+                                                    {% if choice.0 == item.weight %}{{ choice.1 }}{% endif %}
+                                                {% endfor %}
+                                            </span>
+                                        </div>
                                         <div class="item-quantity">تعداد: {{ item.quantity }}</div>
                                     </div>
                                     <div class="item-price">{{ item.price|floatformat:0 }} تومان</div>

--- a/shop/views.py
+++ b/shop/views.py
@@ -1103,7 +1103,9 @@ def checkout(request):
                         order=order,
                         product=cart_item.product,
                         quantity=cart_item.quantity,
-                        price=cart_item.product.price
+                        price=cart_item.get_unit_price(),  # Use weight-adjusted price
+                        grind_type=cart_item.grind_type,
+                        weight=cart_item.weight
                     )
                 
                 # Clear cart


### PR DESCRIPTION
Add grind type and weight fields to order items to store user selections and apply weight-based pricing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cbc3663-b444-4fc0-9cde-4492cbd60f25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cbc3663-b444-4fc0-9cde-4492cbd60f25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

