### PR TITLE
Update checkout to only use post delivery

### DIFF
--- a/shop/admin.py
+++ b/shop/admin.py
@@ -254,7 +254,7 @@ class OrderAdmin(admin.ModelAdmin):
     def start_shipping_preparation(self, request, queryset):
         """Start shipping preparation for postal orders"""
         updated = 0
-        for order in queryset.filter(delivery_method='postal'):
+        for order in queryset.filter(delivery_method='post'):
             if order.start_shipping_preparation(request.user):
                 updated += 1
         self.message_user(request, f'{updated} سفارش پستی وارد مرحله آماده‌سازی ارسال شد.')

--- a/shop/migrations/0017_alter_order_delivery_method_post_only.py
+++ b/shop/migrations/0017_alter_order_delivery_method_post_only.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def set_delivery_method_to_post(apps, schema_editor):
+    Order = apps.get_model('shop', 'Order')
+    Order.objects.filter(delivery_method__in=['pickup', 'postal']).update(delivery_method='post')
+
+
+def reverse_set_delivery_method_to_post(apps, schema_editor):
+    # Cannot reliably restore previous values; default to 'post'
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shop', '0016_cartitem_add_grind_weight_and_unique'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_delivery_method_to_post, reverse_code=reverse_set_delivery_method_to_post),
+        migrations.AlterField(
+            model_name='order',
+            name='delivery_method',
+            field=models.CharField(choices=[('post', 'ارسال پستی')], default='post', max_length=20),
+        ),
+    ]

--- a/shop/models.py
+++ b/shop/models.py
@@ -120,13 +120,12 @@ class Order(models.Model):
     ]
     
     DELIVERY_CHOICES = [
-        ('pickup', 'دریافت حضوری'),
-        ('postal', 'ارسال پستی'),
+        ('post', 'ارسال پستی'),
     ]
     
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     status = models.CharField(max_length=25, choices=STATUS_CHOICES, default='pending_payment')
-    delivery_method = models.CharField(max_length=20, choices=DELIVERY_CHOICES, default='pickup')
+    delivery_method = models.CharField(max_length=20, choices=DELIVERY_CHOICES, default='post')
     delivery_fee = models.DecimalField(max_digits=10, decimal_places=2, default=0)
     subtotal = models.DecimalField(max_digits=10, decimal_places=2, default=0)
     total_amount = models.DecimalField(max_digits=10, decimal_places=2, default=0)
@@ -191,7 +190,7 @@ class Order(models.Model):
     
     def start_shipping_preparation(self, user=None):
         """Start shipping preparation for postal orders"""
-        if self.status == 'ready' and self.delivery_method == 'postal':
+        if self.status == 'ready' and self.delivery_method == 'post':
             return self.transition_to('shipping_preparation', user)
         return False
     

--- a/shop/templates/shop/checkout.html
+++ b/shop/templates/shop/checkout.html
@@ -424,16 +424,7 @@
                                 
                                 <div class="delivery-options">
                                     <label class="delivery-option">
-                                        <input type="radio" name="delivery_method" value="pickup" checked>
-                                        <div class="delivery-icon">
-                                            <i class="fas fa-store"></i>
-                                        </div>
-                                        <div class="delivery-title">دریافت حضوری</div>
-                                        <div class="delivery-description">رایگان</div>
-                                    </label>
-                                    
-                                    <label class="delivery-option">
-                                        <input type="radio" name="delivery_method" value="post">
+                                        <input type="radio" name="delivery_method" value="post" checked>
                                         <div class="delivery-icon">
                                             <i class="fas fa-shipping-fast"></i>
                                         </div>

--- a/shop/templates/shop/order_detail.html
+++ b/shop/templates/shop/order_detail.html
@@ -445,10 +445,7 @@
                                                          <div class="info-card">
                                  <div class="info-label">روش تحویل</div>
                                  <div class="info-value">
-                                     {% if order.delivery_method == 'delivery' %}تحویل در محل
-                                     {% elif order.delivery_method == 'pickup' %}تحویل حضوری
-                                     {% else %}تعیین نشده
-                                     {% endif %}
+                                     {% if order.delivery_method == 'post' %}ارسال پستی{% else %}تعیین نشده{% endif %}
                                  </div>
                              </div>
                             


### PR DESCRIPTION
Remove in-person delivery and standardize 'post' as the sole delivery method to fix checkout validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9baf19de-d351-4bee-9857-23fbce3e06a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9baf19de-d351-4bee-9857-23fbce3e06a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

