### PR TITLE
Merge conflicting database migrations

### DIFF
--- a/shop/migrations/0018_add_slugs.py
+++ b/shop/migrations/0018_add_slugs.py
@@ -38,16 +38,29 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Step 1: Add nullable, non-unique fields to avoid UNIQUE violations during table rewrite
         migrations.AddField(
             model_name='category',
             name='slug',
-            field=models.SlugField(blank=True, db_index=True, max_length=160, unique=True),
+            field=models.SlugField(blank=True, null=True, db_index=True, max_length=160),
         ),
         migrations.AddField(
             model_name='product',
             name='slug',
-            field=models.SlugField(blank=True, db_index=True, max_length=220, unique=True),
+            field=models.SlugField(blank=True, null=True, db_index=True, max_length=220),
         ),
+        # Step 2: Populate unique slugs for existing rows
         migrations.RunPython(populate_category_slugs, migrations.RunPython.noop),
         migrations.RunPython(populate_product_slugs, migrations.RunPython.noop),
+        # Step 3: Enforce uniqueness and non-null after data backfill
+        migrations.AlterField(
+            model_name='category',
+            name='slug',
+            field=models.SlugField(blank=True, null=False, db_index=True, max_length=160, unique=True),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='slug',
+            field=models.SlugField(blank=True, null=False, db_index=True, max_length=220, unique=True),
+        ),
     ]


### PR DESCRIPTION
Modify `shop/migrations/0018_add_slugs.py` to add slug fields in a three-step process.

This resolves `sqlite3.IntegrityError: UNIQUE constraint failed` during `migrate` by adding nullable/non-unique fields first, populating them, then enforcing unique/non-null constraints.

---
<a href="https://cursor.com/background-agent?bcId=bc-df16dd93-9a31-4ce8-a46c-76a46aa84ebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df16dd93-9a31-4ce8-a46c-76a46aa84ebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

