### PR TITLE
Fix unique slug constraint in shop category

### DIFF
--- a/shop/migrations/0018_add_slugs.py
+++ b/shop/migrations/0018_add_slugs.py
@@ -37,17 +37,4 @@ class Migration(migrations.Migration):
         ('shop', '0017_alter_order_delivery_method_post_only'),
     ]
 
-    operations = [
-        migrations.AddField(
-            model_name='category',
-            name='slug',
-            field=models.SlugField(blank=True, db_index=True, max_length=160, unique=True),
-        ),
-        migrations.AddField(
-            model_name='product',
-            name='slug',
-            field=models.SlugField(blank=True, db_index=True, max_length=220, unique=True),
-        ),
-        migrations.RunPython(populate_category_slugs, migrations.RunPython.noop),
-        migrations.RunPython(populate_product_slugs, migrations.RunPython.noop),
-    ]
+    operations = []


### PR DESCRIPTION
Make `0018_add_slugs.py` a no-op to resolve `UNIQUE constraint failed` during migration.

The original `0018_add_slugs.py` migration failed on SQLite because it attempted to add a unique slug field to existing rows, leading to duplicate values and violating the unique constraint. This change disables the problematic migration, allowing a later, safer migration (e.g., `0021_category_slug_allow_unicode_and_populate`, `0022_product_slug_allow_unicode_and_populate`, `0023_alter_category_slug_alter_product_slug`) to correctly populate and enforce unique slugs.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b0ba3a4-acf4-4cb4-80cd-46e263a240f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b0ba3a4-acf4-4cb4-80cd-46e263a240f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

