### PR TITLE
Manage product categories and products

### DIFF
--- a/shop/management/commands/seed_catalog.py
+++ b/shop/management/commands/seed_catalog.py
@@ -1,0 +1,153 @@
+from django.core.management.base import BaseCommand
+from django.core.files.base import ContentFile
+from django.core.files import File
+from decimal import Decimal
+from pathlib import Path
+import io
+
+from shop.models import Category, Product
+
+
+class Command(BaseCommand):
+    help = "Reset and seed categories and products based on predefined catalog rules"
+
+    def add_arguments(self, parser):
+        parser.add_argument('--no-input', action='store_true', help='Run non-interactively')
+
+    def handle(self, *args, **options):
+        base_dir = Path(__file__).resolve().parents[3]
+        media_dir = base_dir / 'media'
+        local_cats_dir = base_dir / 'categories'
+        media_dir.mkdir(parents=True, exist_ok=True)
+
+        self.stdout.write(self.style.WARNING('Deleting existing products and categories...'))
+        Product.objects.all().delete()
+        Category.objects.all().delete()
+
+        # Create categories
+        category_names = [
+            'قهوه تک دان',
+            'قهوه گلد',
+            'پودریجات',
+            'قهوه های ترکیب شده(بلند)',
+            'سیروپ ها',
+        ]
+
+        # Assign local images to categories if available
+        local_cat_images = list(sorted(local_cats_dir.glob('coffee_*.jpg')))
+        created_categories = {}
+        for idx, name in enumerate(category_names):
+            cat = Category.objects.create(name=name, description='')
+            # Attach image from local pool if exists
+            if local_cat_images:
+                img_path = local_cat_images[idx % len(local_cat_images)]
+                try:
+                    with open(img_path, 'rb') as f:
+                        cat.image.save(img_path.name, File(f), save=True)
+                except Exception:
+                    pass
+            created_categories[name] = cat
+            self.stdout.write(self.style.SUCCESS(f"Created category: {name}"))
+
+        # Utility: configure per-category rules
+        def set_product_options(product: Product, category_name: str):
+            # Defaults
+            default_grinds = ['whole_bean', 'coarse', 'medium_coarse', 'medium', 'medium_fine', 'fine']
+            default_weights = ['250g', '500g', '1kg']
+
+            if category_name == 'قهوه گلد':
+                product.available_grinds = []
+                product.available_weights = ['100g', '250g', '500g']
+                product.weight_multipliers = {
+                    '100g': 1.0,
+                    '250g': 2.5,
+                    '500g': 5.0,
+                }
+            elif category_name == 'پودریجات':
+                product.available_grinds = []
+                product.available_weights = ['250g', '500g']
+                product.weight_multipliers = {
+                    '250g': 1.0,
+                    '500g': 2.0,
+                }
+            elif category_name == 'سیروپ ها':
+                product.available_grinds = []
+                product.available_weights = []
+                product.weight_multipliers = {}
+            else:
+                # تک دان + بلند
+                product.available_grinds = default_grinds
+                product.available_weights = default_weights
+                product.weight_multipliers = {}
+
+        # Seed products per category
+        def create_product(name: str, price_int: int, category_name: str, stock: int = 100, featured: bool = False, description: str = ''):
+            product = Product(
+                name=name,
+                description=description or 'محصول ثبت شده به صورت خودکار',
+                price=Decimal(price_int),
+                category=created_categories[category_name],
+                stock=stock,
+                featured=featured,
+            )
+            set_product_options(product, category_name)
+            product.save()
+            self.stdout.write(self.style.SUCCESS(f"Added product: {name} ({category_name})"))
+
+        # قهوه تک دان
+        single_origin = [
+            ('عربیکا کلمبیا', 385000),
+            ('عربیکا اتیوپی', 299000),
+            ('عربیکا کنیا', 357000),
+            ('عربیکا برزیل', 282000),
+            ('ربستا اندونزی', 385000),
+            ('ربستا اوگاندا', 299000),
+        ]
+        for name, price in single_origin:
+            create_product(name, price, 'قهوه تک دان')
+
+        # قهوه گلد
+        gold = [
+            ('گلد اکوادور', 264000),
+            ('گلد هند', 210000),
+            ('گلد برزیل', 210000),
+        ]
+        for name, price in gold:
+            create_product(name, price, 'قهوه گلد')
+
+        # پودریجات
+        powders = [
+            ('کاپوچینو', 155000),
+            ('هات چاکلت', 155000),
+            ('ماسالا', 155000),
+            ('کافی میت', 87000),
+        ]
+        for name, price in powders:
+            create_product(name, price, 'پودریجات')
+
+        # قهوه های ترکیب شده(بلند)
+        blends = [
+            ('فول کافئین', 287000),
+            ('70*30 پایه ربستا', 299000),
+            ('50*50', 327000),
+            ('100 عربیکا', 390000),
+        ]
+        for name, price in blends:
+            create_product(name, price, 'قهوه های ترکیب شده(بلند)')
+
+        # سیروپ ها
+        syrups = [
+            'سیروپ کارامل',
+            'سیروپ ایریش',
+            'سیروپ نارگیل',
+            'سیروپ سیب',
+            'سیروپ بلوبری',
+            'سیروپ لیمو',
+            'سیروپ موهیتو',
+            'سیروپ زعفران',
+            'سیروپ آناناس',
+        ]
+        for name in syrups:
+            create_product(name, 477000, 'سیروپ ها')
+
+        self.stdout.write(self.style.SUCCESS('Catalog seeding complete.'))

--- a/shop/models.py
+++ b/shop/models.py
@@ -42,6 +42,7 @@ class Product(models.Model):
     ]
     
     WEIGHT_CHOICES = [
+        ('100g', '100 گرم'),
         ('250g', '250 گرم'),
         ('500g', '500 گرم'),
         ('1kg', '1 کیلوگرم'),

--- a/shop/templates/shop/product_detail.html
+++ b/shop/templates/shop/product_detail.html
@@ -1231,75 +1231,71 @@
 
             <!-- Product Options -->
             <div class="options-container">
-                <!-- Grind Type Selection -->
-                <div class="option-group">
+                {# Grind Selection - rendered only if there are available grinds #}
+                {% if available_grinds %}
+                <div class="option-group" id="grindGroup">
                     <div class="option-label">
                         <i class="fas fa-cog"></i>
                         نحوه آسیاب
                     </div>
                     <div class="custom-select">
                         <div class="select-display" id="grindSelect">
-                            <span id="grindDisplay">اسیاب نشده</span>
+                            <span id="grindDisplay">
+                                {% with first_grind=available_grinds.0 %}
+                                    {% for code,label in grind_choices %}
+                                        {% if code == first_grind %}{{ label }}{% endif %}
+                                    {% endfor %}
+                                {% endwith %}
+                            </span>
                             <i class="fas fa-chevron-down select-arrow"></i>
                         </div>
                         <div class="select-options" id="grindOptions">
-                            <div class="select-option selected" data-value="whole_bean">
-                                <span>اسیاب نشده</span>
+                            {% for g in available_grinds %}
+                            <div class="select-option{% if forloop.first %} selected{% endif %}" data-value="{{ g }}">
+                                <span>
+                                    {% for code,label in grind_choices %}
+                                        {% if code == g %}{{ label }}{% endif %}
+                                    {% endfor %}
+                                </span>
                             </div>
-                            <div class="select-option" data-value="coarse">
-                                <span>ترک</span>
-                            </div>
-                            <div class="select-option" data-value="medium_coarse">
-                                <span>موکاپات</span>
-                            </div>
-                            <div class="select-option" data-value="medium">
-                                <span>اسپرسو ساز نیمه صنعتی</span>
-                            </div>
-                            <div class="select-option" data-value="medium_fine">
-                                <span>اسپرسوساز صنعتی</span>
-                            </div>
-                            <div class="select-option" data-value="fine">
-                                <span>اسپرسوساز خانگی</span>
-                            </div>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>
+                {% endif %}
 
-                <!-- Weight Selection -->
-                <div class="option-group">
+                {# Weight Selection - rendered only if there are available weights #}
+                {% if available_weights %}
+                <div class="option-group" id="weightGroup">
                     <div class="option-label">
                         <i class="fas fa-weight-hanging"></i>
                         مقدار وزن
                     </div>
                     <div class="custom-select">
                         <div class="select-display" id="weightSelect">
-                            <span id="weightDisplay">250 گرم</span>
+                            <span id="weightDisplay">
+                                {% with first_weight=available_weights.0 %}
+                                    {% for code,label in weight_choices %}
+                                        {% if code == first_weight %}{{ label }}{% endif %}
+                                    {% endfor %}
+                                {% endwith %}
+                            </span>
                             <i class="fas fa-chevron-down select-arrow"></i>
                         </div>
                         <div class="select-options" id="weightOptions">
-                            <div class="select-option selected" data-value="250g" data-multiplier="1">
-                                <span>250 گرم</span>
-                                <span class="option-price">{{ product.price|floatformat:0 }} تومان</span>
+                            {% for w in available_weights %}
+                            <div class="select-option{% if forloop.first %} selected{% endif %}" data-value="{{ w }}" data-multiplier="{{ weight_multipliers.w|default:1 }}">
+                                <span>
+                                    {% for code,label in weight_choices %}
+                                        {% if code == w %}{{ label }}{% endif %}
+                                    {% endfor %}
+                                </span>
                             </div>
-                            <div class="select-option" data-value="500g" data-multiplier="2">
-                                <span>500 گرم</span>
-                                <span class="option-price">{{ product.price|floatformat:0|add:"0" }} تومان</span>
-                            </div>
-                            <div class="select-option" data-value="1kg" data-multiplier="4">
-                                <span>1 کیلوگرم</span>
-                                <span class="option-price">{{ product.price|floatformat:0|add:"0" }} تومان</span>
-                            </div>
-                            <div class="select-option" data-value="5kg" data-multiplier="18">
-                                <span>5 کیلوگرم</span>
-                                <span class="option-price">{{ product.price|floatformat:0|add:"0" }} تومان</span>
-                            </div>
-                            <div class="select-option" data-value="10kg" data-multiplier="35">
-                                <span>10 کیلوگرم</span>
-                                <span class="option-price">{{ product.price|floatformat:0|add:"0" }} تومان</span>
-                            </div>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
 
             <!-- Quantity Selection -->
@@ -1441,18 +1437,17 @@ document.addEventListener('DOMContentLoaded', function() {
     const productId = {{ product.id }};
     
     // Weight multipliers - FIXED: 500g = 2x, 1kg = 4x
-    const weightMultipliers = {
-        '250g': 1,
-        '500g': 2,
-        '1kg': 4,
-        '5kg': 18,
-        '10kg': 35
-    };
+    const weightMultipliers = JSON.parse(document.getElementById('weight_multipliers_json').textContent || '{}');
+    const availableGrinds = JSON.parse(document.getElementById('available_grinds_json').textContent || '[]');
+    const availableWeights = JSON.parse(document.getElementById('available_weights_json').textContent || '[]');
 
-    // Current selections
-    let currentGrind = 'whole_bean';
-    let currentWeight = '250g';
-    let currentQuantity = 1;
+    let currentGrind = availableGrinds.length ? availableGrinds[0] : '';
+    let currentWeight = availableWeights.length ? availableWeights[0] : '';
+
+    function getCurrentMultiplier() {
+        if (!availableWeights.length) { return 1; }
+        return weightMultipliers[currentWeight] || 1;
+    }
 
     // Initialize dropdowns
     initializeDropdowns();
@@ -1503,7 +1498,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 weightDisplay.textContent = optionEl.querySelector('span').textContent;
                 currentWeight = optionEl.dataset.value;
                 updatePriceDisplay();
-                updateWeightPrices();
                 closeDropdown(weightSelect, weightOptions);
             }
         });
@@ -1595,23 +1589,11 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function updatePriceDisplay() {
-        const multiplier = weightMultipliers[currentWeight];
+        const multiplier = getCurrentMultiplier();
         const unitPrice = basePrice * multiplier;
         const totalPrice = unitPrice * currentQuantity;
         
         document.getElementById('priceValue').textContent = Math.round(totalPrice).toLocaleString();
-    }
-
-    function updateWeightPrices() {
-        const weightOptions = document.querySelectorAll('#weightOptions .select-option');
-        weightOptions.forEach(option => {
-            const multiplier = parseFloat(option.dataset.multiplier);
-            const price = Math.round(basePrice * multiplier);
-            const priceElement = option.querySelector('.option-price');
-            if (priceElement) {
-                priceElement.textContent = price.toLocaleString() + ' تومان';
-            }
-        });
     }
 
     function initializeActionButtons() {
@@ -1854,9 +1836,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     }
-
-    // Initialize weight prices
-    updateWeightPrices();
 
     // GSAP Animations
     if (typeof gsap !== 'undefined') {

--- a/shop/views.py
+++ b/shop/views.py
@@ -265,13 +265,13 @@ def product_detail(request, product_id=None, slug=None):
         '10kg': 35.0
     }
     
-    # Set default available options if not configured
-    if not product.available_grinds:
+    # Use product-configured options as-is; only fill safe defaults when completely unset (None)
+    if product.available_grinds is None:
         product.available_grinds = ['whole_bean', 'coarse', 'medium', 'fine']
-    if not product.available_weights:
+    if product.available_weights is None:
         product.available_weights = ['250g', '500g', '1kg']
     if not product.weight_multipliers:
-        product.weight_multipliers = {k: v for k, v in default_multipliers.items() if k in product.available_weights}
+        product.weight_multipliers = {k: v for k, v in default_multipliers.items() if product.available_weights and k in product.available_weights}
 
     context = {
         'product': product,


### PR DESCRIPTION
Adds a `seed_catalog` command to reset and populate the product catalog with custom categories, products, and dynamic display rules.

The user provided detailed specifications for different product categories, including custom weight options (e.g., 100g for 'قهوه گلد'), and rules for hiding grind or weight selections on the product detail page for certain categories (e.g., 'سیروپ ها' should have no weight/grind options). This required changes to the product model, view logic, and the product detail template to support dynamic rendering of these options.

---
<a href="https://cursor.com/background-agent?bcId=bc-28266b57-464e-401c-967a-2d95d4f9b26c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28266b57-464e-401c-967a-2d95d4f9b26c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

