### PR TITLE
Update product grid to three columns

### DIFF
--- a/shop/templates/shop/category_detail.html
+++ b/shop/templates/shop/category_detail.html
@@ -90,7 +90,7 @@
 
 .product-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 2rem;
     justify-items: center;
 }

--- a/shop/templates/shop/product_list.html
+++ b/shop/templates/shop/product_list.html
@@ -372,7 +372,7 @@
 
 .product-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 2rem;
 }
 


### PR DESCRIPTION
Update product grids on category and product list pages to display 3 columns instead of 2.

---
<a href="https://cursor.com/background-agent?bcId=bc-b917d18f-0189-4ae7-a865-928da19f620d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b917d18f-0189-4ae7-a865-928da19f620d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

