### PR TITLE
Fix sms unicode encoding error

### DIFF
--- a/coffe_shop/settings.py
+++ b/coffe_shop/settings.py
@@ -250,10 +250,11 @@ LOGGING = {
             'class': 'logging.FileHandler',
             'filename': BASE_DIR / 'debug.log',
             'formatter': 'verbose',
+            'encoding': 'utf-8',
         },
         'console': {
             'level': 'INFO',
-            'class': 'logging.StreamHandler',
+            'class': 'shop.logging_utils.SafeConsoleHandler',
             'formatter': 'simple',
         },
     },

--- a/shop/logging_utils.py
+++ b/shop/logging_utils.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Optional
+
+
+class SafeConsoleHandler(logging.StreamHandler):
+    """
+    Stream handler that safely writes unicode messages to consoles with limited encodings
+    (e.g., Windows cp1252). Characters not supported by the console encoding are
+    replaced instead of raising UnicodeEncodeError.
+
+    File logging should be configured separately with UTF-8 encoding to preserve
+    original characters.
+    """
+
+    def __init__(self, stream: Optional[object] = None) -> None:
+        # Use default StreamHandler behavior (stderr) to match Django's console handler semantics
+        super().__init__(stream)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            encoding = getattr(stream, 'encoding', None) or 'utf-8'
+            try:
+                safe_msg = msg.encode(encoding, errors='replace').decode(encoding, errors='replace')
+            except Exception:
+                safe_msg = msg
+            stream.write(safe_msg + self.terminator)
+            self.flush()
+        except Exception:
+            self.handleError(record)


### PR DESCRIPTION
Implement safe Unicode logging for console and UTF-8 for file logs to prevent `UnicodeEncodeError`.

The `UnicodeEncodeError` occurred because the default Windows console encoding (cp1252) could not handle Persian characters when logging SMS messages. This change ensures that console logging gracefully replaces unencodable characters, while file logs retain full Unicode fidelity.

---
<a href="https://cursor.com/background-agent?bcId=bc-9481287f-54a2-4726-8c1a-564a656b9f68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9481287f-54a2-4726-8c1a-564a656b9f68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

