### PR TITLE
Fix template syntax error and other bugs

### DIFF
--- a/shop/templates/shop/checkout.html
+++ b/shop/templates/shop/checkout.html
@@ -534,11 +534,7 @@
                             {% endif %}
                             <div class="price-row total">
                                 <span>مبلغ نهایی:</span>
-                                {% if intro_margin_preview and intro_margin_preview > 0 %}
-                                <span id="total-amount">{{ total|add:-intro_margin_preview|floatformat:0 }} تومان</span>
-                                {% else %}
-                                <span id="total-amount">{{ total|floatformat:0 }} تومان</span>
-                                {% endif %}
+                                <span id="total-amount">{{ final_total|floatformat:0 }} تومان</span>
                             </div>
                         </div>
                         

--- a/shop/views.py
+++ b/shop/views.py
@@ -489,6 +489,14 @@ def checkout(request):
     except Exception:
         intro_margin_preview = 0
 
+    # Compute final total after applying intro margin preview (for display only)
+    try:
+        final_total = total - Decimal(intro_margin_preview or 0)
+        if final_total < 0:
+            final_total = Decimal('0')
+    except Exception:
+        final_total = total
+
     if request.method == 'POST':
         form = CheckoutForm(request.POST, user=request.user)
         if form.is_valid():
@@ -520,6 +528,7 @@ def checkout(request):
         'total': total,
         'user_addresses': list(UserAddress.objects.filter(user=request.user)),
         'intro_margin_preview': intro_margin_preview,
+        'final_total': final_total,
     }
     return render(request, 'shop/checkout.html', context)
 


### PR DESCRIPTION
Compute final total in checkout view to fix `TemplateSyntaxError` caused by invalid template arithmetic.

The `add` filter in Django templates expects two distinct arguments for arithmetic operations (e.g., `|add:value`). Using a negative sign directly with a variable (e.g., `|add:-variable`) is not supported, leading to a `TemplateSyntaxError`. This PR resolves the issue by performing the subtraction in the Python view and passing the pre-calculated `final_total` to the template.

---
<a href="https://cursor.com/background-agent?bcId=bc-94ef5209-4866-482b-89e8-86f0641e713e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94ef5209-4866-482b-89e8-86f0641e713e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

