### PR TITLE
Fix profile dropdown and navbar spacing

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -9,7 +9,7 @@ body:not(.home-page) .navbar {
   justify-content: space-between;
   align-items: center;
   z-index: 99999999; /* High z-index for navbar, but still below dropdown */
-  overflow: hidden;
+  overflow: visible;
 }
 
 body:not(.home-page) .navbar::before {
@@ -325,3 +325,9 @@ body:not(.home-page) .navbar .cart-count {
     padding-top: 80px;
   }
 } */
+
+/* Remove extra gap under navbar on non-home pages */
+body:not(.home-page) .main-content {
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}

--- a/staticfiles/shop/navbar-blur.css
+++ b/staticfiles/shop/navbar-blur.css
@@ -9,7 +9,7 @@ body:not(.home-page) .navbar {
   justify-content: space-between;
   align-items: center;
   z-index: 1000;
-  overflow: hidden;
+  overflow: visible;
 }
 
 body:not(.home-page) .navbar::before {
@@ -316,12 +316,18 @@ body:not(.home-page) .navbar .cart-count {
 }
 
 /* Ensure content doesn't get hidden behind fixed navbar */
-body:not(.home-page) {
+/* body:not(.home-page) {
   padding-top: 100px;
-}
+} */
 
-@media (max-width: 768px) {
+/* @media (max-width: 768px) {
   body:not(.home-page) {
     padding-top: 80px;
   }
+} */
+
+/* Remove extra gap under navbar on non-home pages */
+body:not(.home-page) .main-content {
+  padding-top: 0 !important;
+  margin-top: 0 !important;
 }


### PR DESCRIPTION
Fixes profile dropdown clipping and removes unwanted gap below the navbar on non-homepage views.

---
<a href="https://cursor.com/background-agent?bcId=bc-682a700b-d0c3-4e82-becc-1b17db2b1e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-682a700b-d0c3-4e82-becc-1b17db2b1e14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

