### PR TITLE
Fix navbar background rotation on non-home pages

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -21,6 +21,7 @@ body:not(.home-page) .navbar::before {
   background-position: center;
   filter: blur(15px);
   transform: scale(1.1);
+  animation: none;
   z-index: -1;
 }
 

--- a/shop/templates/shop/base.html
+++ b/shop/templates/shop/base.html
@@ -50,7 +50,7 @@
           <!-- Stylesheets -->
     <link rel="stylesheet" href="{% static 'shop/style.css' %}?v=4.1">
     <link rel="stylesheet" href="{% static 'shop/style-enhancements.css' %}?v=2.0">
-            <link rel="stylesheet" href="{% static 'shop/navbar-blur.css' %}?v=1.1">
+            <link rel="stylesheet" href="{% static 'shop/navbar-blur.css' %}?v=1.2">
         <link rel="stylesheet" href="{% static 'shop/dropdown-fix.css' %}?v=1.0">
         {% block extra_css %}{% endblock %}
     


### PR DESCRIPTION
Stop navbar background rotation on non-home pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cdc77c7-1c0b-49e9-9079-6ae0ad6f5f29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1cdc77c7-1c0b-49e9-9079-6ae0ad6f5f29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

