### PR TITLE
Fix horizontal scrolling bug on pages

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -9,7 +9,9 @@ body:not(.home-page) .navbar {
   justify-content: space-between;
   align-items: center;
   z-index: 1000; /* Keep below dropdown but above content */
-  overflow: visible;
+  overflow-y: visible;
+  overflow-x: hidden;
+  contain: paint;
 }
 
 body:not(.home-page) .navbar::before {
@@ -23,6 +25,7 @@ body:not(.home-page) .navbar::before {
   transform: scale(1.1);
   animation: none;
   z-index: -1;
+  overflow-x: clip;
 }
 
 /* Optional tinted overlay */
@@ -37,6 +40,8 @@ body:not(.home-page) .navbar::after {
     transparent 100%
   );
   z-index: -1;
+  animation: none !important;
+  transform: none !important;
 }
 
 /* Navbar content styling */

--- a/shop/static/shop/style.css
+++ b/shop/static/shop/style.css
@@ -10,6 +10,11 @@ html, body {
     margin: 0;
     padding: 0;
     height: 100%;
+    overflow-x: hidden;
+    overflow-y: overlay;
+    scrollbar-gutter: stable both-edges;
+    overscroll-behavior-x: none;
+    touch-action: pan-y;
 }
 
 body {

--- a/shop/templates/shop/base.html
+++ b/shop/templates/shop/base.html
@@ -479,5 +479,17 @@
     {% endif %}
 
     {% block extra_scripts %}{% endblock %}
+
+    <script>
+    (function(){
+        if (!document.body.classList.contains('home-page')) {
+            window.addEventListener('scroll', function(){
+                if (window.scrollX !== 0) {
+                    window.scrollTo(0, window.scrollY);
+                }
+            }, { passive: true });
+        }
+    })();
+    </script>
 </body>
 </html> 


### PR DESCRIPTION
Fixes horizontal page shifting on non-home pages by preventing overflow and locking horizontal scroll.

The page would sometimes shift horizontally when scrolling vertically on non-home pages. This was caused by global overflow issues, unstable scrollbars, and the navbar's animated elements extending beyond the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-68811558-3545-42f5-bc2d-3e07ac011598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68811558-3545-42f5-bc2d-3e07ac011598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

