### PR TITLE
Fix order status template syntax error

### DIFF
--- a/shop/templates/shop/order_detail.html
+++ b/shop/templates/shop/order_detail.html
@@ -560,7 +560,7 @@
                                         <div class="timeline-date">{{ order.created_at|date:"Y/m/d H:i" }}</div>
                                     </div>
                                 </div>
-                                <div class="timeline-item {% if order.status in ['in_transit', 'delivered'] %}active{% endif %}" data-step="in_transit">
+                                <div class="timeline-item {% if order.status == 'in_transit' or order.status == 'delivered' %}active{% endif %}" data-step="in_transit">
                                     <div class="timeline-content">
                                         <div class="timeline-title">بسته در حال رسیدن به مقصد است</div>
                                         <div class="timeline-date">{{ order.created_at|date:"Y/m/d H:i" }}</div>


### PR DESCRIPTION
Fix `TemplateSyntaxError` in `order_detail.html` by replacing invalid list membership syntax with `or` conditions.

---
<a href="https://cursor.com/background-agent?bcId=bc-de065402-c326-4ad7-a7e0-c1d7da75abf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de065402-c326-4ad7-a7e0-c1d7da75abf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

