### PR TITLE
Fix ssl protocol error on homepage

### DIFF
--- a/coffe_shop/settings.py
+++ b/coffe_shop/settings.py
@@ -183,12 +183,15 @@ X_FRAME_OPTIONS = 'DENY'
 
 # Production-only secure settings
 if not DEBUG:
-    SECURE_SSL_REDIRECT = True
+    SECURE_SSL_REDIRECT = os.environ.get('DJANGO_SECURE_SSL_REDIRECT', 'true').lower() == 'true'
     SECURE_HSTS_SECONDS = int(os.environ.get('DJANGO_SECURE_HSTS_SECONDS', '31536000'))
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+else:
+    # In development, default to not forcing HTTPS unless explicitly enabled
+    SECURE_SSL_REDIRECT = os.environ.get('DJANGO_SECURE_SSL_REDIRECT', 'false').lower() == 'true'
 
 # Phase 3: Caching Configuration (Enhanced)
 CACHES = {


### PR DESCRIPTION
Make `SECURE_SSL_REDIRECT` configurable via environment variable and default to `False` in development to prevent `ERR_SSL_PROTOCOL_ERROR` when running without TLS.

---
<a href="https://cursor.com/background-agent?bcId=bc-4eae4913-7e74-4d3b-aa9e-129a41fe0d51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4eae4913-7e74-4d3b-aa9e-129a41fe0d51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

