### PR TITLE
Fix https access to http server

### DIFF
--- a/coffe_shop/settings.py
+++ b/coffe_shop/settings.py
@@ -38,7 +38,7 @@ import os
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-^mmy1%awrcdj)jb_zlmknow@g-nvnk%!e#(5ffpds&ahwko3h(')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
+DEBUG = os.environ.get('DJANGO_DEBUG', 'True').lower() == 'true'
 
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', 'localhost,127.0.0.1,testserver').split(',')
 
@@ -190,8 +190,9 @@ if not DEBUG:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 else:
-    # In development, default to not forcing HTTPS unless explicitly enabled
+    # In development, never force HTTPS unless explicitly enabled via env
     SECURE_SSL_REDIRECT = os.environ.get('DJANGO_SECURE_SSL_REDIRECT', 'false').lower() == 'true'
+    SECURE_HSTS_SECONDS = 0
 
 # Phase 3: Caching Configuration (Enhanced)
 CACHES = {


### PR DESCRIPTION
Default `DEBUG` to True and disable HSTS in development to prevent HTTPS errors with the local server.

The changes prevent the Django development server from forcing HTTPS, which it does not support by default. This resolves `ERR_SSL_PROTOCOL_ERROR` and "You're accessing the development server over HTTPS, but it only supports HTTP" messages during local development.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd7a4f4c-3f1c-4b96-8480-33285fdb9a80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd7a4f4c-3f1c-4b96-8480-33285fdb9a80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

