### PR TITLE
Debug navbar dropdown stacking issue

### DIFF
--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -11,7 +11,7 @@ body:not(.home-page) .navbar {
   z-index: 1000; /* Keep below dropdown but above content */
   overflow-y: visible;
   overflow-x: hidden;
-  contain: paint;
+  contain: none;
 }
 
 body:not(.home-page) .navbar::before {


### PR DESCRIPTION
Remove `contain: paint` from the non-home page navbar to fix the profile dropdown being clipped and hidden under page content.

The `contain: paint` property on `body:not(.home-page) .navbar` created a paint containment context that clipped the absolutely positioned profile dropdown when it extended beyond the navbar's bounds. Changing this to `contain: none` allows the dropdown to render freely, leveraging its existing high `z-index` to appear above all other content.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ff35048-d14b-44ca-a47e-f01129582472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ff35048-d14b-44ca-a47e-f01129582472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

