### PR TITLE
Fix profile dropdown overflow on non-home pages

### DIFF
--- a/shop/static/shop/dropdown-fix.css
+++ b/shop/static/shop/dropdown-fix.css
@@ -2,129 +2,141 @@
 
 /* Base Profile Dropdown - Used in most pages */
 .profile-dropdown {
-    position: relative !important;
-    display: inline-block !important;
-    z-index: 2147483647 !important; /* Maximum z-index value */
-    direction: ltr !important;
+	position: relative !important;
+	display: inline-block !important;
+	z-index: 2147483647 !important; /* Maximum z-index value */
+	direction: ltr !important;
 }
 
 .dropdown-toggle {
-    position: relative !important;
-    z-index: 2147483647 !important;
-    cursor: pointer !important;
+	position: relative !important;
+	z-index: 2147483647 !important;
+	cursor: pointer !important;
 }
 
 .dropdown-menu {
-    position: absolute !important;
-    z-index: 2147483647 !important;
-    top: 100% !important;
-    left: 0 !important;
-    pointer-events: auto !important;
+	position: absolute !important;
+	z-index: 2147483647 !important;
+	top: 100% !important;
+	left: 0 !important;
+	pointer-events: auto !important;
 }
 
 .dropdown-menu.show {
-    z-index: 2147483647 !important;
-    pointer-events: auto !important;
+	z-index: 2147483647 !important;
+	pointer-events: auto !important;
 }
 
 /* Hero Profile Dropdown - Used in home page */
 .hero-profile-dropdown {
-    position: relative !important;
-    pointer-events: auto !important;
-    z-index: 2147483647 !important;
+	position: relative !important;
+	pointer-events: auto !important;
+	z-index: 2147483647 !important;
 }
 
 .hero-dropdown-toggle {
-    position: relative !important;
-    z-index: 2147483647 !important;
+	position: relative !important;
+	z-index: 2147483647 !important;
 }
 
 .hero-dropdown-menu {
-    position: absolute !important;
-    z-index: 2147483647 !important;
-    top: 100% !important;
-    right: 0 !important;
-    pointer-events: auto !important;
+	position: absolute !important;
+	z-index: 2147483647 !important;
+	top: 100% !important;
+	right: 0 !important;
+	pointer-events: auto !important;
 }
 
 .hero-dropdown-menu.show {
-    z-index: 2147483647 !important;
-    pointer-events: auto !important;
+	z-index: 2147483647 !important;
+	pointer-events: auto !important;
 }
 
 /* Ensure navbar and other elements stay below dropdown */
 .navbar,
 .navbar-overlay,
 .site-header {
-    z-index: 99999999 !important;
+	z-index: 99999999 !important;
 }
 
 /* Ensure modals don't interfere with dropdown */
 .modal {
-    z-index: 999999 !important;
+	z-index: 999999 !important;
 }
 
 /* Ensure messages don't interfere with dropdown */
 .messages {
-    z-index: 999999 !important;
+	z-index: 999999 !important;
 }
 
 /* Fix any potential stacking context issues */
 .container,
 .main-content,
 .content {
-    position: relative !important;
-    z-index: 1 !important;
+	position: relative !important;
+	z-index: 1 !important;
 }
 
 /* Ensure dropdown items are clickable */
 .dropdown-item,
 .hero-dropdown-item {
-    position: relative !important;
-    z-index: 2147483647 !important;
-    pointer-events: auto !important;
+	position: relative !important;
+	z-index: 2147483647 !important;
+	pointer-events: auto !important;
 }
 
 /* Fix for any fixed positioned elements that might interfere */
 .fixed-element {
-    z-index: 99999999 !important;
+	z-index: 99999999 !important;
 }
 
 /* Responsive fixes */
 @media (max-width: 768px) {
-    .profile-dropdown,
-    .hero-profile-dropdown {
-        z-index: 2147483647 !important;
-    }
-    
-    .dropdown-menu,
-    .hero-dropdown-menu {
-        z-index: 2147483647 !important;
-        position: absolute !important;
-    }
+	.profile-dropdown,
+	.hero-profile-dropdown {
+		z-index: 2147483647 !important;
+	}
+	
+	.dropdown-menu,
+	.hero-dropdown-menu {
+		z-index: 2147483647 !important;
+		position: absolute !important;
+	}
 }
 
 /* Stable layering for navbar and dropdown on non-home pages */
 body:not(.home-page) .navbar {
-    position: fixed !important;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 10000 !important;
+	position: fixed !important;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 10000 !important;
 }
 
 body:not(.home-page) .navbar .profile-dropdown {
-    position: relative !important;
-    z-index: 10001 !important;
+	position: relative !important;
+	z-index: 10001 !important;
 }
 
 body:not(.home-page) .navbar .dropdown-menu {
-    position: absolute !important;
-    z-index: 10002 !important;
+	position: absolute !important;
+	z-index: 10002 !important;
 }
 
 .main-content, .container, .content {
-    position: relative !important;
-    z-index: 1 !important;
+	position: relative !important;
+	z-index: 1 !important;
+}
+
+/* --- Non-home navbar overflow & RTL-safe dropdown alignment overrides --- */
+body:not(.home-page) .navbar,
+body:not(.home-page) .navbar .nav-links,
+body:not(.home-page) .navbar .profile-dropdown {
+	overflow: visible !important;
+}
+
+body:not(.home-page) .navbar .dropdown-menu {
+	right: 0 !important;
+	left: auto !important;
 }
 

--- a/shop/static/shop/navbar-blur.css
+++ b/shop/static/shop/navbar-blur.css
@@ -9,8 +9,7 @@ body:not(.home-page) .navbar {
   justify-content: space-between;
   align-items: center;
   z-index: 1000; /* Keep below dropdown but above content */
-  overflow-y: visible;
-  overflow-x: hidden;
+  overflow: visible; /* Allow dropdown to overflow outside navbar */
   contain: none;
 }
 


### PR DESCRIPTION
Fix profile navbar dropdown appearing under content on non-home pages by setting `overflow: visible` and refining stacking context.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd75f8f1-8ed2-4bce-851e-6718184da21d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd75f8f1-8ed2-4bce-851e-6718184da21d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

