### PR TITLE
Fix profile dropdown alignment on non-home pages

### DIFF
--- a/shop/static/shop/dropdown-fix.css
+++ b/shop/static/shop/dropdown-fix.css
@@ -136,7 +136,7 @@ body:not(.home-page) .navbar .profile-dropdown {
 }
 
 body:not(.home-page) .navbar .dropdown-menu {
-	right: 0 !important;
-	left: auto !important;
+	left: 0 !important;
+	right: auto !important;
 }
 


### PR DESCRIPTION
Adjust profile dropdown positioning on non-home pages to prevent it from overflowing off-screen to the left.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfb88304-b795-4a68-a28d-fdf7fd284b23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfb88304-b795-4a68-a28d-fdf7fd284b23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

