### PR TITLE
Fix missing styles due to js placement

### DIFF
--- a/coffe_shop/urls.py
+++ b/coffe_shop/urls.py
@@ -18,6 +18,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 # Explicit imports to prevent namespace clashes between user-facing and admin views
 from shop import views as shop_views
 from shop import admin_views as admin_views
@@ -64,7 +65,7 @@ urlpatterns = [
     
     # AI Assistant URLs
     # path('ai/chat/', ai_chat, name='ai_chat'),
-    # path('ai/voice/', voice_chat, name='voice_chat'),
+    # path('ai/voice/', voice_chat, name='ai_voice'),
 
     # SEO
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
@@ -85,4 +86,4 @@ urlpatterns += [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Fixes static files not loading in development by using `staticfiles_urlpatterns` to correctly serve assets from app directories.

---
<a href="https://cursor.com/background-agent?bcId=bc-708d0f27-47b3-4cdc-ae87-50d419ea0199">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-708d0f27-47b3-4cdc-ae87-50d419ea0199">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

