### PR TITLE
Fix category page redirect loop

### DIFF
--- a/shop/views.py
+++ b/shop/views.py
@@ -13,6 +13,7 @@ from django.db.models import Q, Sum, Count, Avg, F, Min, Max
 from django.core.paginator import Paginator
 from django.utils import timezone
 from datetime import datetime, timedelta
+from django.utils.encoding import iri_to_uri
 from .models import *
 from .forms import *
 from .error_handling import (
@@ -173,7 +174,9 @@ def category_detail(request, category_id=None, slug=None):
         try:
             canonical_path = category.get_absolute_url()
             # Only redirect when we're not already at the canonical path
-            if canonical_path and request.path != canonical_path:
+            request_uri = iri_to_uri(request.path)
+            canonical_uri = iri_to_uri(canonical_path) if canonical_path else None
+            if canonical_uri and request_uri != canonical_uri:
                 return redirect(canonical_path, permanent=True)
         except Exception:
             pass
@@ -205,7 +208,9 @@ def product_detail(request, product_id=None, slug=None):
         if request.method == 'GET':
             try:
                 canonical_path = product.get_absolute_url()
-                if canonical_path and request.path != canonical_path:
+                request_uri = iri_to_uri(request.path)
+                canonical_uri = iri_to_uri(canonical_path) if canonical_path else None
+                if canonical_uri and request_uri != canonical_uri:
                     return redirect(canonical_path, permanent=True)
             except Exception:
                 pass

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -2,4 +2,4 @@ home = /usr/bin
 include-system-site-packages = false
 version = 3.13.3
 executable = /usr/bin/python3.13
-command = /usr/bin/python3 -m venv --without-pip /workspace/venv
+command = /usr/bin/python3 -m venv /workspace/venv


### PR DESCRIPTION
Normalize URIs in category and product canonical redirect comparisons to fix infinite redirect loops.

The redirect loop occurred because `request.path` and `get_absolute_url()` were compared directly, leading to mismatches due to different URL encodings (e.g., Unicode vs. percent-encoded) even when the paths were logically identical. Normalizing both to IRIs before comparison ensures a correct match and prevents unnecessary 301 redirects.

---
<a href="https://cursor.com/background-agent?bcId=bc-81854a16-e3a5-4bde-a259-83f36f882797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81854a16-e3a5-4bde-a259-83f36f882797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

