### PR TITLE
Setup django project on cpanel

### DIFF
--- a/shop/migrations/0002_update_order_status_choices.py
+++ b/shop/migrations/0002_update_order_status_choices.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('shop', '0001_initial'),  # Adjust this to the latest migration number
+        ('shop', '0007_video_order_delivery_fee_order_delivery_method_and_more'),
     ]
 
     operations = [

--- a/shop/migrations/0015_productinteraction_remove_analyticsevent_category_and_more.py
+++ b/shop/migrations/0015_productinteraction_remove_analyticsevent_category_and_more.py
@@ -102,16 +102,6 @@ class Migration(migrations.Migration):
             name='updated_at',
         ),
         migrations.AddField(
-            model_name='cartitem',
-            name='grind_type',
-            field=models.CharField(choices=[('whole_bean', 'دانه کامل'), ('coarse', 'درشت (فرنچ پرس)'), ('medium_coarse', 'متوسط درشت (کمکس)'), ('medium', 'متوسط (دریپ)'), ('medium_fine', 'متوسط ریز (اروپرس)'), ('fine', 'ریز (اسپرسو)'), ('extra_fine', 'فوق ریز (ترک)')], default='whole_bean', max_length=20),
-        ),
-        migrations.AddField(
-            model_name='cartitem',
-            name='weight',
-            field=models.CharField(choices=[('250g', '250 گرم'), ('500g', '500 گرم'), ('1kg', '1 کیلوگرم'), ('5kg', '5 کیلوگرم'), ('10kg', '10 کیلوگرم')], default='250g', max_length=10),
-        ),
-        migrations.AddField(
             model_name='customersegment',
             name='engagement_score',
             field=models.FloatField(default=0.0),

--- a/shop/migrations/0016_merge.py
+++ b/shop/migrations/0016_merge.py
@@ -10,36 +10,4 @@ class Migration(migrations.Migration):
         ('shop', '0015_productinteraction_remove_analyticsevent_category_and_more'),
     ]
 
-    operations = [
-        migrations.AddField(
-            model_name='orderitem',
-            name='grind_type',
-            field=models.CharField(
-                choices=[
-                    ('whole_bean', 'اسیاب نشده'),
-                    ('coarse', 'ترک'),
-                    ('medium_coarse', 'موکاپات'),
-                    ('medium', 'اسپرسو ساز نیمه صنعتی'),
-                    ('medium_fine', 'اسپرسوساز صنعتی'),
-                    ('fine', 'اسپرسوساز خانگی'),
-                ],
-                default='whole_bean',
-                max_length=20
-            ),
-        ),
-        migrations.AddField(
-            model_name='orderitem',
-            name='weight',
-            field=models.CharField(
-                choices=[
-                    ('250g', '250 گرم'),
-                    ('500g', '500 گرم'),
-                    ('1kg', '1 کیلوگرم'),
-                    ('5kg', '5 کیلوگرم'),
-                    ('10kg', '10 کیلوگرم'),
-                ],
-                default='250g',
-                max_length=10
-            ),
-        ),
-    ]
+    operations = []

--- a/shop/migrations/0017_alter_cartitem_grind_type.py
+++ b/shop/migrations/0017_alter_cartitem_grind_type.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('shop', '0016_merge'),
+        ('shop', '0016_cartitem_add_grind_weight_and_unique'),
     ]
 
     operations = [

--- a/shop/migrations/0019_ensure_cartitem_unique_index.py
+++ b/shop/migrations/0019_ensure_cartitem_unique_index.py
@@ -5,4 +5,6 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
      dependencies = [ ('shop', '0018_merge_20250809_0301'), ] 
-     operations = [ migrations.RunSQL( "CREATE UNIQUE INDEX IF NOT EXISTS shop_cartitem_unique " "ON shop_cartitem (cart_id, product_id, grind_type, weight);", "DROP INDEX IF EXISTS shop_cartitem_unique;", ), ] 
+     # This migration used to add a redundant unique index overlapping unique_together.
+     # It is now a no-op to avoid duplicate indexes while retaining migration order.
+     operations = []


### PR DESCRIPTION
Fix Django migration conflicts to prevent "column already exists" errors.

This PR removes duplicate `AddField` operations for `OrderItem.grind_type`, `OrderItem.weight`, `CartItem.grind_type`, and `CartItem.weight`, and corrects migration dependencies to ensure fields exist before subsequent migrations modify them.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ef50140-2a71-4441-b613-6cb642f2ac1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ef50140-2a71-4441-b613-6cb642f2ac1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

